### PR TITLE
Fix #8 with $icon-size references in scss

### DIFF
--- a/src/assets/scss/custom/_icons.scss
+++ b/src/assets/scss/custom/_icons.scss
@@ -22,7 +22,7 @@
 }
 
 .icon-xl + .icon-text {
-	width: calc(100% - $icon-size-xl - 1);
+	width: calc(100% - #{$icon-size-xl} - 1);
 }
 
 .icon-lg {
@@ -35,7 +35,7 @@
 }
 
 .icon-lg + .icon-text {
-	width: calc(100% - $icon-size-lg - 1);
+	width: calc(100% - #{$icon-size-lg} - 1);
 }
 
 .icon-sm {
@@ -48,7 +48,7 @@
 }
 
 .icon-sm + .icon-text {
-	width: calc(100% - $icon-size-sm - 1);
+	width: calc(100% - #{$icon-size-sm} - 1);
 }
 
 


### PR DESCRIPTION
Fixes #8 with $icon-size references in the _icons.scss file that was causing ng build --prod to fail.